### PR TITLE
[Feat] Add DatabasePicker extension for database selection

### DIFF
--- a/apps/portal/packages/app/src/App.tsx
+++ b/apps/portal/packages/app/src/App.tsx
@@ -38,6 +38,7 @@ import { RequirePermission } from '@backstage/plugin-permission-react';
 import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
 import { NotificationsPage } from '@backstage/plugin-notifications';
 import { SignalsDisplay } from '@backstage/plugin-signals';
+import { DatabasePickerExtension } from './scaffolder';
 
 const app = createApp({
   apis,
@@ -74,6 +75,8 @@ const app = createApp({
   },
 });
 
+const scaffolderFieldExtensions = [DatabasePickerExtension];
+
 const routes = (
   <FlatRoutes>
     <Route path="/" element={<Navigate to="catalog" />} />
@@ -93,7 +96,11 @@ const routes = (
         <ReportIssue />
       </TechDocsAddons>
     </Route>
-    <Route path="/create" element={<ScaffolderPage />} />
+    <Route path="/create" element={<ScaffolderPage />}>
+      {scaffolderFieldExtensions.map(Extension => (
+        <Extension key={Extension.name} />
+      ))}
+    </Route>
     <Route path="/api-docs" element={<ApiExplorerPage />} />
     <Route
       path="/catalog-import"

--- a/apps/portal/packages/app/src/scaffolder/DatabasePickerExtension/DatabasePicker.tsx
+++ b/apps/portal/packages/app/src/scaffolder/DatabasePickerExtension/DatabasePicker.tsx
@@ -1,0 +1,14 @@
+import { FieldExtensionComponentProps } from '@backstage/plugin-scaffolder-react';
+
+export const DatabasePicker = ({
+  onChange,
+  rawErrors,
+  required,
+  formData,
+  uiSchema,
+  schema,
+  formContext,
+}: FieldExtensionComponentProps<string>) => {
+  // Todo: Implementation
+  return <></>;
+};

--- a/apps/portal/packages/app/src/scaffolder/DatabasePickerExtension/extension.ts
+++ b/apps/portal/packages/app/src/scaffolder/DatabasePickerExtension/extension.ts
@@ -1,0 +1,13 @@
+import { scaffolderPlugin } from '@backstage/plugin-scaffolder';
+import { createScaffolderFieldExtension } from '@backstage/plugin-scaffolder-react';
+import { DatabasePicker } from './DatabasePicker';
+
+export const DatabasePickerExtension = scaffolderPlugin.provide(
+  createScaffolderFieldExtension({
+    name: 'DatabasePicker',
+    component: DatabasePicker,
+    validation: (value, validation, context) => {
+        // Todo: Implement validation logic
+    },
+  }),
+);

--- a/apps/portal/packages/app/src/scaffolder/DatabasePickerExtension/index.ts
+++ b/apps/portal/packages/app/src/scaffolder/DatabasePickerExtension/index.ts
@@ -1,0 +1,2 @@
+export * from './DatabasePicker';
+export * from './extension';

--- a/apps/portal/packages/app/src/scaffolder/index.ts
+++ b/apps/portal/packages/app/src/scaffolder/index.ts
@@ -1,0 +1,1 @@
+export * from './DatabasePickerExtension/index';


### PR DESCRIPTION
This PR scaffold the baseline custom field extension structure within the Backstage portal.

**Changes:**

- Created the folder structure: `packages/app/src/scaffolder/DatabasePickerExtension`.

- Created the barebones `DatabasePicker.tsx` and `extension.ts` files.

- Registered the empty extension in `App.tsx` so it loads without errors.