### PR TITLE
[Git Provider][Phase 1] Go Operator - Interface Definition & Provider Factory

### DIFF
--- a/apps/operator/api/v1alpha1/heliosapp_types.go
+++ b/apps/operator/api/v1alpha1/heliosapp_types.go
@@ -64,7 +64,7 @@ type HeliosAppSpec struct {
 
 	// TriggerType is the type of trigger to use for the pipeline
 	// +optional
-	// +kubebuilder:validation:Enum=gitea-push;db-migrate
+	// +kubebuilder:validation:Enum=git-push;gitea-push;db-migrate
 	// +kubebuilder:default="gitea-push"
 	TriggerType string `json:"triggerType,omitempty"`
 

--- a/apps/operator/config/crd/bases/app.helios.io_heliosapps.yaml
+++ b/apps/operator/config/crd/bases/app.helios.io_heliosapps.yaml
@@ -383,6 +383,7 @@ spec:
                 default: gitea-push
                 description: TriggerType is the type of trigger to use for the pipeline
                 enum:
+                - git-push
                 - gitea-push
                 - db-migrate
                 type: string

--- a/apps/operator/internal/controller/gitopssync/reconciler.go
+++ b/apps/operator/internal/controller/gitopssync/reconciler.go
@@ -45,7 +45,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *appv1alpha1.HeliosApp, 
 	token, username := r.resolveCredentials(ctx, app)
 
 	if token == "" {
-		err := fmt.Errorf("GitOps token is empty. Check Secret or GITEA_TOKEN env var")
+		err := fmt.Errorf("GitOps token is empty. Check GitOpsSecretRef or provider credentials")
 		log.Error(err, "Authentication failed")
 		r.updateFailedStatus(ctx, app, "GitOps token missing")
 		return nil

--- a/apps/operator/internal/controller/gitopssync/reconciler.go
+++ b/apps/operator/internal/controller/gitopssync/reconciler.go
@@ -15,6 +15,7 @@ import (
 
 	appv1alpha1 "github.com/helios-platform-team/helios-platform/apps/operator/api/v1alpha1"
 	"github.com/helios-platform-team/helios-platform/apps/operator/internal/gitops"
+	"github.com/helios-platform-team/helios-platform/apps/operator/internal/provider"
 )
 
 // GitFactory creates a GitOps client for the given repo, user, and token.
@@ -91,10 +92,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *appv1alpha1.HeliosApp, 
 func (r *Reconciler) resolveCredentials(ctx context.Context, app *appv1alpha1.HeliosApp) (string, string) {
 	log := logf.FromContext(ctx)
 
-	token := os.Getenv("GITEA_TOKEN")
-	username := os.Getenv("GITEA_USER")
+	token := readTokenEnv(provider.Default)
+	username := readUserEnv(provider.Default)
 	if username == "" {
-		username = "git"
+		username = provider.Default.DefaultUsername()
 	}
 
 	if app.Spec.GitOpsSecretRef != "" {
@@ -133,4 +134,22 @@ func (r *Reconciler) updateFailedStatus(ctx context.Context, app *appv1alpha1.He
 func computeHash(data []byte) string {
 	hash := sha256.Sum256(data)
 	return hex.EncodeToString(hash[:])
+}
+
+// readTokenEnv reads the auth token from the provider-specific env var,
+// falling back to the generic GIT_TOKEN.
+func readTokenEnv(p provider.GitProvider) string {
+	if t := os.Getenv(p.TokenEnvVar()); t != "" {
+		return t
+	}
+	return os.Getenv("GIT_TOKEN")
+}
+
+// readUserEnv reads the username from the provider-specific env var,
+// falling back to the generic GIT_USER.
+func readUserEnv(p provider.GitProvider) string {
+	if u := os.Getenv(p.UserEnvVar()); u != "" {
+		return u
+	}
+	return os.Getenv("GIT_USER")
 }

--- a/apps/operator/internal/controller/shared/gitea_url.go
+++ b/apps/operator/internal/controller/shared/gitea_url.go
@@ -1,46 +1,13 @@
 package shared
 
 import (
-	"os"
-	"strings"
+	"github.com/helios-platform-team/helios-platform/apps/operator/internal/provider"
 )
 
-// RewriteGiteaURL translates an external Gitea URL (e.g., http://localhost:3030/...)
-// to the in-cluster service URL so in-cluster components can reach it.
+// RewriteGiteaURL translates an external git URL to the in-cluster service URL
+// so in-cluster components can reach it. Delegates to the configured git provider.
 //
-// Falls back to the original URL if GITEA_URL / GITEA_INTERNAL_URL are not set.
+// Deprecated: Use provider.Default.RewriteURL() directly for provider-agnostic code.
 func RewriteGiteaURL(repoURL string) string {
-	externalURL := os.Getenv("GITEA_URL")
-	internalURL := os.Getenv("GITEA_INTERNAL_URL")
-
-	// Normalize: remove trailing slashes
-	externalURL = strings.TrimSuffix(externalURL, "/")
-	internalURL = strings.TrimSuffix(internalURL, "/")
-
-	if externalURL != "" && internalURL != "" {
-		rewritten := strings.Replace(repoURL, externalURL, internalURL, 1)
-		if rewritten != repoURL {
-			return rewritten
-		}
-
-		const (
-			localhost = "localhost"
-			loopback  = "127.0.0.1"
-		)
-		if strings.Contains(externalURL, localhost) {
-			altExternal := strings.Replace(externalURL, localhost, loopback, 1)
-			rewritten = strings.Replace(repoURL, altExternal, internalURL, 1)
-			if rewritten != repoURL {
-				return rewritten
-			}
-		}
-		if strings.Contains(externalURL, loopback) {
-			altExternal := strings.Replace(externalURL, loopback, localhost, 1)
-			rewritten = strings.Replace(repoURL, altExternal, internalURL, 1)
-			if rewritten != repoURL {
-				return rewritten
-			}
-		}
-	}
-	return repoURL
+	return provider.Default.RewriteURL(repoURL)
 }

--- a/apps/operator/internal/controller/tekton/mapper.go
+++ b/apps/operator/internal/controller/tekton/mapper.go
@@ -4,21 +4,23 @@ import (
 	"cmp"
 
 	appv1alpha1 "github.com/helios-platform-team/helios-platform/apps/operator/api/v1alpha1"
-	heliosCue "github.com/helios-platform-team/helios-platform/apps/operator/internal/controller/shared"
 	cueModel "github.com/helios-platform-team/helios-platform/apps/operator/internal/cue"
+	"github.com/helios-platform-team/helios-platform/apps/operator/internal/provider"
 )
 
 const defaultPipelineName = "from-code-to-cluster"
 
 // MapCRDToTektonInput converts HeliosApp CRD to TektonInput for CUE rendering.
 func MapCRDToTektonInput(app *appv1alpha1.HeliosApp) cueModel.TektonInput {
+	p := provider.Default
+
 	input := cueModel.TektonInput{
 		AppName:         app.Name,
 		Namespace:       app.Namespace,
-		GitRepo:         heliosCue.RewriteGiteaURL(app.Spec.GitRepo),
+		GitRepo:         p.RewriteURL(app.Spec.GitRepo),
 		GitBranch:       app.Spec.GitBranch,
 		ImageRepo:       app.Spec.ImageRepo,
-		GitOpsRepo:      heliosCue.RewriteGiteaURL(app.Spec.GitOpsRepo),
+		GitOpsRepo:      p.RewriteURL(app.Spec.GitOpsRepo),
 		GitOpsPath:      app.Spec.GitOpsPath,
 		GitOpsBranch:    app.Spec.GitOpsBranch,
 		GitOpsSecretRef: app.Spec.GitOpsSecretRef,
@@ -45,12 +47,12 @@ func MapCRDToTektonInput(app *appv1alpha1.HeliosApp) cueModel.TektonInput {
 	input.GitBranch = cmp.Or(input.GitBranch, "main")
 	input.GitOpsBranch = cmp.Or(input.GitOpsBranch, "main")
 	input.GitOpsSecretRef = cmp.Or(input.GitOpsSecretRef, "helios-gitops-bot")
-	input.WebhookSecret = cmp.Or(input.WebhookSecret, "gitea-webhook-secret")
+	input.WebhookSecret = cmp.Or(input.WebhookSecret, p.WebhookSecretName())
 	// Derive the database secret name dynamically from app name if not explicitly set
 	if input.DatabaseSecretRef == "" {
 		input.DatabaseSecretRef = app.Name + "-db-secret"
 	}
-	input.TriggerType = cmp.Or(input.TriggerType, "gitea-push")
+	input.TriggerType = cmp.Or(input.TriggerType, p.DefaultTriggerType())
 	if input.PipelineName == "" {
 		input.PipelineName = defaultPipelineName
 		input.PipelineType = defaultPipelineName

--- a/apps/operator/internal/provider/factory.go
+++ b/apps/operator/internal/provider/factory.go
@@ -1,0 +1,26 @@
+package provider
+
+import (
+	"os"
+)
+
+// Default is the provider instance for the currently configured git provider.
+// It is set at init time based on the GIT_PROVIDER_TYPE environment variable.
+var Default GitProvider
+
+func init() {
+	Default = NewProviderFromEnv(os.Getenv("GIT_PROVIDER_TYPE"))
+}
+
+// NewProviderFromEnv creates a GitProvider based on the given provider type string.
+// Falls back to GiteaProvider when the type is empty or unrecognized.
+func NewProviderFromEnv(providerType string) GitProvider {
+	switch Type(providerType) {
+	case TypeGithub:
+		return NewGitHubProvider()
+	case TypeGitLab:
+		return NewGiteaProvider() // fallback until GitLab is implemented
+	default:
+		return NewGiteaProvider()
+	}
+}

--- a/apps/operator/internal/provider/gitea.go
+++ b/apps/operator/internal/provider/gitea.go
@@ -54,3 +54,7 @@ func (p *GiteaProvider) DefaultUsername() string {
 	}
 	return "git"
 }
+
+func (p *GiteaProvider) TokenEnvVar() string { return "GITEA_TOKEN" }
+
+func (p *GiteaProvider) UserEnvVar() string { return "GITEA_USER" }

--- a/apps/operator/internal/provider/gitea.go
+++ b/apps/operator/internal/provider/gitea.go
@@ -1,0 +1,56 @@
+package provider
+
+import (
+	"os"
+	"strings"
+)
+
+// GiteaProvider implements GitProvider for Gitea instances.
+type GiteaProvider struct{}
+
+// NewGiteaProvider creates a GiteaProvider.
+func NewGiteaProvider() *GiteaProvider { return &GiteaProvider{} }
+
+func (p *GiteaProvider) Name() Type { return TypeGitea }
+
+func (p *GiteaProvider) RewriteURL(repoURL string) string {
+	externalURL := strings.TrimSuffix(os.Getenv("GITEA_URL"), "/")
+	internalURL := strings.TrimSuffix(os.Getenv("GITEA_INTERNAL_URL"), "/")
+
+	if externalURL == "" || internalURL == "" {
+		return repoURL
+	}
+
+	rewritten := strings.Replace(repoURL, externalURL, internalURL, 1)
+	if rewritten != repoURL {
+		return rewritten
+	}
+
+	if strings.Contains(externalURL, "localhost") {
+		altExternal := strings.Replace(externalURL, "localhost", "127.0.0.1", 1)
+		rewritten = strings.Replace(repoURL, altExternal, internalURL, 1)
+		if rewritten != repoURL {
+			return rewritten
+		}
+	}
+	if strings.Contains(externalURL, "127.0.0.1") {
+		altExternal := strings.Replace(externalURL, "127.0.0.1", "localhost", 1)
+		rewritten = strings.Replace(repoURL, altExternal, internalURL, 1)
+		if rewritten != repoURL {
+			return rewritten
+		}
+	}
+
+	return repoURL
+}
+
+func (p *GiteaProvider) DefaultTriggerType() string { return "gitea-push" }
+
+func (p *GiteaProvider) WebhookSecretName() string { return "gitea-webhook-secret" }
+
+func (p *GiteaProvider) DefaultUsername() string {
+	if u := os.Getenv("GITEA_USER"); u != "" {
+		return u
+	}
+	return "git"
+}

--- a/apps/operator/internal/provider/gitea_test.go
+++ b/apps/operator/internal/provider/gitea_test.go
@@ -59,6 +59,12 @@ func TestGiteaProvider_Defaults(t *testing.T) {
 	if got := p.DefaultUsername(); got != "git" {
 		t.Errorf("DefaultUsername() = %q, want %q", got, "git")
 	}
+	if got := p.TokenEnvVar(); got != "GITEA_TOKEN" {
+		t.Errorf("TokenEnvVar() = %q, want %q", got, "GITEA_TOKEN")
+	}
+	if got := p.UserEnvVar(); got != "GITEA_USER" {
+		t.Errorf("UserEnvVar() = %q, want %q", got, "GITEA_USER")
+	}
 }
 
 func TestGitHubProvider_RewriteURL(t *testing.T) {
@@ -86,6 +92,12 @@ func TestGitHubProvider_Defaults(t *testing.T) {
 	}
 	if got := p.DefaultUsername(); got != "git" {
 		t.Errorf("DefaultUsername() = %q, want %q", got, "git")
+	}
+	if got := p.TokenEnvVar(); got != "GITHUB_TOKEN" {
+		t.Errorf("TokenEnvVar() = %q, want %q", got, "GITHUB_TOKEN")
+	}
+	if got := p.UserEnvVar(); got != "GITHUB_USER" {
+		t.Errorf("UserEnvVar() = %q, want %q", got, "GITHUB_USER")
 	}
 }
 

--- a/apps/operator/internal/provider/gitea_test.go
+++ b/apps/operator/internal/provider/gitea_test.go
@@ -1,0 +1,120 @@
+package provider
+
+import (
+	"testing"
+)
+
+func TestGiteaProvider_RewriteURL(t *testing.T) {
+	p := &GiteaProvider{}
+	t.Setenv("GITEA_INTERNAL_URL", "http://gitea-http.gitea.svc.cluster.local:3000")
+
+	t.Run("rewrites exact external match", func(t *testing.T) {
+		t.Setenv("GITEA_URL", "http://localhost:3030")
+		in := "http://localhost:3030/helios-platform/test-2.git"
+		want := "http://gitea-http.gitea.svc.cluster.local:3000/helios-platform/test-2.git"
+		if got := p.RewriteURL(in); got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("rewrites loopback variant (127.0.0.1)", func(t *testing.T) {
+		t.Setenv("GITEA_URL", "http://localhost:3030")
+		in := "http://127.0.0.1:3030/helios-platform/test-2.git"
+		want := "http://gitea-http.gitea.svc.cluster.local:3000/helios-platform/test-2.git"
+		if got := p.RewriteURL(in); got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("falls back when GITEA_URL missing", func(t *testing.T) {
+		t.Setenv("GITEA_URL", "")
+		in := "http://127.0.0.1:3030/helios-platform/test-2.git"
+		if got := p.RewriteURL(in); got != in {
+			t.Fatalf("got %q, want %q", got, in)
+		}
+	})
+
+	t.Run("falls back when GITEA_INTERNAL_URL missing", func(t *testing.T) {
+		t.Setenv("GITEA_URL", "http://localhost:3030")
+		t.Setenv("GITEA_INTERNAL_URL", "")
+		in := "http://localhost:3030/helios-platform/test-2.git"
+		if got := p.RewriteURL(in); got != in {
+			t.Fatalf("got %q, want %q", got, in)
+		}
+	})
+}
+
+func TestGiteaProvider_Defaults(t *testing.T) {
+	p := NewGiteaProvider()
+
+	if got := p.Name(); got != TypeGitea {
+		t.Errorf("Name() = %q, want %q", got, TypeGitea)
+	}
+	if got := p.DefaultTriggerType(); got != "gitea-push" {
+		t.Errorf("DefaultTriggerType() = %q, want %q", got, "gitea-push")
+	}
+	if got := p.WebhookSecretName(); got != "gitea-webhook-secret" {
+		t.Errorf("WebhookSecretName() = %q, want %q", got, "gitea-webhook-secret")
+	}
+	if got := p.DefaultUsername(); got != "git" {
+		t.Errorf("DefaultUsername() = %q, want %q", got, "git")
+	}
+}
+
+func TestGitHubProvider_RewriteURL(t *testing.T) {
+	p := &GitHubProvider{}
+	t.Setenv("GITHUB_URL", "https://github.mycompany.com")
+	t.Setenv("GITHUB_INTERNAL_URL", "http://github-enterprise.default.svc.cluster.local")
+	in := "https://github.mycompany.com/myorg/myrepo.git"
+	want := "http://github-enterprise.default.svc.cluster.local/myorg/myrepo.git"
+	if got := p.RewriteURL(in); got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestGitHubProvider_Defaults(t *testing.T) {
+	p := NewGitHubProvider()
+
+	if got := p.Name(); got != TypeGithub {
+		t.Errorf("Name() = %q, want %q", got, TypeGithub)
+	}
+	if got := p.DefaultTriggerType(); got != "git-push" {
+		t.Errorf("DefaultTriggerType() = %q, want %q", got, "git-push")
+	}
+	if got := p.WebhookSecretName(); got != "webhook-secret" {
+		t.Errorf("WebhookSecretName() = %q, want %q", got, "webhook-secret")
+	}
+	if got := p.DefaultUsername(); got != "git" {
+		t.Errorf("DefaultUsername() = %q, want %q", got, "git")
+	}
+}
+
+func TestNewProviderFromEnv(t *testing.T) {
+	t.Run("empty type returns Gitea", func(t *testing.T) {
+		p := NewProviderFromEnv("")
+		if p.Name() != TypeGitea {
+			t.Errorf("got %q, want %q", p.Name(), TypeGitea)
+		}
+	})
+
+	t.Run("gitea type returns GiteaProvider", func(t *testing.T) {
+		p := NewProviderFromEnv("gitea")
+		if p.Name() != TypeGitea {
+			t.Errorf("got %q, want %q", p.Name(), TypeGitea)
+		}
+	})
+
+	t.Run("github type returns GitHubProvider", func(t *testing.T) {
+		p := NewProviderFromEnv("github")
+		if p.Name() != TypeGithub {
+			t.Errorf("got %q, want %q", p.Name(), TypeGithub)
+		}
+	})
+
+	t.Run("unknown type falls back to Gitea", func(t *testing.T) {
+		p := NewProviderFromEnv("unknown")
+		if p.Name() != TypeGitea {
+			t.Errorf("got %q, want %q", p.Name(), TypeGitea)
+		}
+	})
+}

--- a/apps/operator/internal/provider/github.go
+++ b/apps/operator/internal/provider/github.go
@@ -1,0 +1,35 @@
+package provider
+
+import (
+	"os"
+	"strings"
+)
+
+// GitHubProvider implements GitProvider for GitHub.com and GitHub Enterprise Server.
+type GitHubProvider struct{}
+
+// NewGitHubProvider creates a GitHubProvider.
+func NewGitHubProvider() *GitHubProvider { return &GitHubProvider{} }
+
+func (p *GitHubProvider) Name() Type { return TypeGithub }
+
+func (p *GitHubProvider) RewriteURL(repoURL string) string {
+	externalURL := strings.TrimSuffix(os.Getenv("GITHUB_URL"), "/")
+	internalURL := strings.TrimSuffix(os.Getenv("GITHUB_INTERNAL_URL"), "/")
+
+	if externalURL == "" || internalURL == "" {
+		return repoURL
+	}
+	return strings.Replace(repoURL, externalURL, internalURL, 1)
+}
+
+func (p *GitHubProvider) DefaultTriggerType() string { return "git-push" }
+
+func (p *GitHubProvider) WebhookSecretName() string { return "webhook-secret" }
+
+func (p *GitHubProvider) DefaultUsername() string {
+	if u := os.Getenv("GITHUB_USER"); u != "" {
+		return u
+	}
+	return "git"
+}

--- a/apps/operator/internal/provider/github.go
+++ b/apps/operator/internal/provider/github.go
@@ -33,3 +33,7 @@ func (p *GitHubProvider) DefaultUsername() string {
 	}
 	return "git"
 }
+
+func (p *GitHubProvider) TokenEnvVar() string { return "GITHUB_TOKEN" }
+
+func (p *GitHubProvider) UserEnvVar() string { return "GITHUB_USER" }

--- a/apps/operator/internal/provider/provider.go
+++ b/apps/operator/internal/provider/provider.go
@@ -1,0 +1,35 @@
+package provider
+
+// Type represents the type of git provider.
+type Type string
+
+const (
+	// TypeGitea represents a Gitea instance.
+	TypeGitea Type = "gitea"
+	// TypeGithub represents GitHub.com or GitHub Enterprise Server.
+	TypeGithub Type = "github"
+	// TypeGitLab represents GitLab.com or self-hosted GitLab.
+	TypeGitLab Type = "gitlab"
+)
+
+// GitProvider defines an abstraction over different git hosting providers.
+// Implementations handle provider-specific URL rewriting, defaults, and configuration.
+type GitProvider interface {
+	// Name returns the provider type identifier (e.g., "gitea", "github").
+	Name() Type
+
+	// RewriteURL translates an external repository URL to an in-cluster URL
+	// that internal components can reach. Returns the original URL if no
+	// rewriting is configured.
+	RewriteURL(externalURL string) string
+
+	// DefaultTriggerType returns the default trigger type for Tekton webhooks.
+	DefaultTriggerType() string
+
+	// WebhookSecretName returns the default Kubernetes Secret name for webhook secrets.
+	WebhookSecretName() string
+
+	// DefaultUsername returns the default username for git authentication
+	// when none is explicitly provided.
+	DefaultUsername() string
+}

--- a/apps/operator/internal/provider/provider.go
+++ b/apps/operator/internal/provider/provider.go
@@ -32,4 +32,10 @@ type GitProvider interface {
 	// DefaultUsername returns the default username for git authentication
 	// when none is explicitly provided.
 	DefaultUsername() string
+
+	// TokenEnvVar returns the environment variable name for the authentication token.
+	TokenEnvVar() string
+
+	// UserEnvVar returns the environment variable name for the git username.
+	UserEnvVar() string
 }


### PR DESCRIPTION
This PR implements **Phase 1** of the Git Provider Decoupling initiative. The goal is to break the hardcoded dependency on Gitea across the Go Operator by introducing a provider-agnostic interface (`GitProvider`) and a Factory pattern.

This change lays the foundation for supporting multiple Git providers (e.g., GitHub, GitLab) while maintaining **100% backwards compatibility** with the existing Gitea setup.

## Behavior Change & Configuration
The active Git provider is now determined via the `GIT_PROVIDER_TYPE` environment variable.

* **Default (Gitea) — No changes required:**
  ```bash
  export GITEA_URL=http://localhost:3030
  export GITEA_INTERNAL_URL=[http://gitea-http.gitea.svc.cluster.local:3000](http://gitea-http.gitea.svc.cluster.local:3000)

* **Switching to GitHub:**
    ```bash
    export GIT_PROVIDER_TYPE=github
    export GITHUB_URL=[https://github.mycompany.com](https://github.mycompany.com)
    export GITHUB_INTERNAL_URL=[http://github-enterprise.default.svc.cluster.local](http://github-enterprise.default.svc.cluster.local)

## Key Changes
### 1. New Core Files (Abstraction & Strategy)
- `internal/provider/provider.go`: Defines the `GitProvider` interface (`RewriteURL`, `DefaultTriggerType`, `WebhookSecretName`, `DefaultUsername`).
- `internal/provider/gitea.go`: `GiteaProvider` implementation, porting the existing legacy URL rewriting logic and lazy-loading env vars.
- `internal/provider/github.go`: `GitHubProvider` implementation, adding support for GitHub Enterprise URL rewriting and generic defaults (`git-push`, `webhook-secret`).
- `internal/provider/factory.go`: Factory initialization utilizing `GIT_PROVIDER_TYPE` to expose a `provider.Default` singleton.

### 2. Refactored Files (Decoupling)
- `internal/controller/shared/gitea_url.go`: Refactored into a backwards-compatible wrapper that delegates directly to `provider.Default.RewriteURL()`.
- `internal/controller/tekton/mapper.go`: Removed hardcoded strings. Now dynamically requests `RewriteURL()`, `WebhookSecretName()`, and `DefaultTriggerType()` from the active provider.
- `internal/controller/gitopssync/reconciler.go`: Cleaned up logs to use provider-agnostic phrasing ("Check `GitOpsSecretRef` or provider credentials" instead of Gitea-specific errors).
- `api/v1alpha1/heliosapp_types.go`: Extended the `TriggerType` enum to support `git-push`, `gitea-push`, and `db-migrate`.
- `config/crd/bases/*.yaml`: Auto-regenerated manifests to include the updated enum values.

## Test & Verification Results
#### Automated Tests
- Added `internal/provider/gitea_test.go` containing 9 robust unit tests covering URL rewriting (Gitea vs GitHub), fallback defaults, and Factory behavior.
- All existing and new tests pass successfully (provider, shared, cue, controller, database, argocd).

#### Local Verification
```bash
$ go build ./... # Passed cleanly
$ go vet ./...   # Passed cleanly
$ make build     # Binary builds successfully, CRDs regenerated
```

## What's Next?
**Phase 2:** Implement the `CredentialResolver` to shift from environment variables to provider-agnostic Kubernetes Secrets.