### PR TITLE
feat(operator): implement 3-tier CredentialResolver interface for git sync authentication (Phase 2)

### DIFF
--- a/apps/operator/internal/controller/gitopssync/reconciler.go
+++ b/apps/operator/internal/controller/gitopssync/reconciler.go
@@ -5,11 +5,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"os"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -23,9 +20,10 @@ type GitFactory func(repo, user, token string) gitops.ClientInterface
 
 // Reconciler handles GitOps manifest sync (credentials + git push + hash).
 type Reconciler struct {
-	Client     client.Client
-	Scheme     *runtime.Scheme
-	GitFactory GitFactory
+	Client      client.Client
+	Scheme      *runtime.Scheme
+	GitFactory  GitFactory
+	Credentials *provider.CredentialResolver
 }
 
 // NewReconciler creates a new GitOps sync Reconciler.
@@ -35,7 +33,12 @@ func NewReconciler(c client.Client, scheme *runtime.Scheme, factory GitFactory) 
 			return gitops.NewClient(repo, user, token)
 		}
 	}
-	return &Reconciler{Client: c, Scheme: scheme, GitFactory: factory}
+	return &Reconciler{
+		Client:      c,
+		Scheme:      scheme,
+		GitFactory:  factory,
+		Credentials: provider.NewCredentialResolver(c, provider.Default),
+	}
 }
 
 // Reconcile resolves GitOps credentials, computes a manifest hash, and syncs
@@ -43,10 +46,8 @@ func NewReconciler(c client.Client, scheme *runtime.Scheme, factory GitFactory) 
 func (r *Reconciler) Reconcile(ctx context.Context, app *appv1alpha1.HeliosApp, manifestBytes []byte) error {
 	log := logf.FromContext(ctx)
 
-	token, username := r.resolveCredentials(ctx, app)
-
-	if token == "" {
-		err := fmt.Errorf("GitOps token is empty. Check GitOpsSecretRef or provider credentials")
+	token, username, err := r.Credentials.ResolveGitCredentials(ctx, app.Namespace, app.Spec.GitOpsSecretRef)
+	if err != nil {
 		log.Error(err, "Authentication failed")
 		r.updateFailedStatus(ctx, app, "GitOps token missing")
 		return nil
@@ -88,41 +89,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, app *appv1alpha1.HeliosApp, 
 	return nil
 }
 
-// resolveCredentials reads the GitOps token and username from a Secret or env var.
-func (r *Reconciler) resolveCredentials(ctx context.Context, app *appv1alpha1.HeliosApp) (string, string) {
-	log := logf.FromContext(ctx)
-
-	token := readTokenEnv(provider.Default)
-	username := readUserEnv(provider.Default)
-	if username == "" {
-		username = provider.Default.DefaultUsername()
-	}
-
-	if app.Spec.GitOpsSecretRef != "" {
-		var secret corev1.Secret
-		if err := r.Client.Get(ctx, types.NamespacedName{Name: app.Spec.GitOpsSecretRef, Namespace: app.Namespace}, &secret); err == nil {
-			if t, ok := secret.Data["token"]; ok {
-				token = string(t)
-			} else if p, ok := secret.Data["password"]; ok {
-				token = string(p)
-			} else {
-				log.Info("Secret found but 'token' or 'password' key is missing", "Secret", app.Spec.GitOpsSecretRef)
-				r.updateFailedStatus(ctx, app, fmt.Sprintf("Secret %s missing 'token' key", app.Spec.GitOpsSecretRef))
-				return "", ""
-			}
-			if u, ok := secret.Data["username"]; ok {
-				username = string(u)
-			}
-		} else {
-			log.Error(err, "Failed to get GitOps Secret", "Secret", app.Spec.GitOpsSecretRef)
-			r.updateFailedStatus(ctx, app, fmt.Sprintf("Secret %s not found", app.Spec.GitOpsSecretRef))
-			return "", ""
-		}
-	}
-
-	return token, username
-}
-
 func (r *Reconciler) updateFailedStatus(ctx context.Context, app *appv1alpha1.HeliosApp, message string) {
 	app.Status.Phase = appv1alpha1.PhaseFailed
 	app.Status.Message = message
@@ -134,22 +100,4 @@ func (r *Reconciler) updateFailedStatus(ctx context.Context, app *appv1alpha1.He
 func computeHash(data []byte) string {
 	hash := sha256.Sum256(data)
 	return hex.EncodeToString(hash[:])
-}
-
-// readTokenEnv reads the auth token from the provider-specific env var,
-// falling back to the generic GIT_TOKEN.
-func readTokenEnv(p provider.GitProvider) string {
-	if t := os.Getenv(p.TokenEnvVar()); t != "" {
-		return t
-	}
-	return os.Getenv("GIT_TOKEN")
-}
-
-// readUserEnv reads the username from the provider-specific env var,
-// falling back to the generic GIT_USER.
-func readUserEnv(p provider.GitProvider) string {
-	if u := os.Getenv(p.UserEnvVar()); u != "" {
-		return u
-	}
-	return os.Getenv("GIT_USER")
 }

--- a/apps/operator/internal/controller/gitopssync/reconciler.go
+++ b/apps/operator/internal/controller/gitopssync/reconciler.go
@@ -23,7 +23,7 @@ type Reconciler struct {
 	Client      client.Client
 	Scheme      *runtime.Scheme
 	GitFactory  GitFactory
-	Credentials *provider.CredentialResolver
+	Credentials provider.CredentialsResolver
 }
 
 // NewReconciler creates a new GitOps sync Reconciler.

--- a/apps/operator/internal/provider/credentials.go
+++ b/apps/operator/internal/provider/credentials.go
@@ -10,17 +10,27 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// CredentialResolver resolves git authentication credentials using a
-// three-tier strategy: explicit app secret → provider default secret → env vars.
-type CredentialResolver struct {
+// CredentialsResolver resolves git authentication credentials.
+type CredentialsResolver interface {
+	// ResolveGitCredentials resolves the token and username for git operations.
+	//
+	// Resolution order:
+	//  1. Explicit secret referenced by secretRef (highest priority)
+	//  2. Provider default secret (e.g., "helios-gitops-bot" for Gitea)
+	//  3. Environment variables (provider-specific with generic fallback)
+	ResolveGitCredentials(ctx context.Context, namespace, secretRef string) (token, username string, err error)
+}
+
+// credentialResolver is the default implementation of CredentialsResolver.
+type credentialResolver struct {
 	client   client.Client
 	provider GitProvider
 }
 
-// NewCredentialResolver creates a CredentialResolver backed by the given
+// NewCredentialResolver creates a CredentialsResolver backed by the given
 // Kubernetes client and git provider.
-func NewCredentialResolver(c client.Client, p GitProvider) *CredentialResolver {
-	return &CredentialResolver{client: c, provider: p}
+func NewCredentialResolver(c client.Client, p GitProvider) CredentialsResolver {
+	return &credentialResolver{client: c, provider: p}
 }
 
 // ResolveGitCredentials resolves the token and username for git operations.
@@ -29,7 +39,7 @@ func NewCredentialResolver(c client.Client, p GitProvider) *CredentialResolver {
 //  1. Explicit secret referenced by secretRef (highest priority)
 //  2. Provider default secret (e.g., "helios-gitops-bot" for Gitea)
 //  3. Environment variables (provider-specific with generic fallback)
-func (r *CredentialResolver) ResolveGitCredentials(
+func (r *credentialResolver) ResolveGitCredentials(
 	ctx context.Context,
 	namespace, secretRef string,
 ) (token, username string, err error) {
@@ -67,7 +77,7 @@ func (r *CredentialResolver) ResolveGitCredentials(
 
 // readSecret looks up a Kubernetes Secret and extracts the token and username.
 // Returns zero values and false if the secret is missing or lacks credentials.
-func (r *CredentialResolver) readSecret(ctx context.Context, namespace, name string) (token, username string, found bool) {
+func (r *credentialResolver) readSecret(ctx context.Context, namespace, name string) (token, username string, found bool) {
 	var secret corev1.Secret
 	if err := r.client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &secret); err != nil {
 		return "", "", false

--- a/apps/operator/internal/provider/credentials.go
+++ b/apps/operator/internal/provider/credentials.go
@@ -1,0 +1,107 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CredentialResolver resolves git authentication credentials using a
+// three-tier strategy: explicit app secret → provider default secret → env vars.
+type CredentialResolver struct {
+	client   client.Client
+	provider GitProvider
+}
+
+// NewCredentialResolver creates a CredentialResolver backed by the given
+// Kubernetes client and git provider.
+func NewCredentialResolver(c client.Client, p GitProvider) *CredentialResolver {
+	return &CredentialResolver{client: c, provider: p}
+}
+
+// ResolveGitCredentials resolves the token and username for git operations.
+//
+// Resolution order:
+//  1. Explicit secret referenced by secretRef (highest priority)
+//  2. Provider default secret (e.g., "helios-gitops-bot" for Gitea)
+//  3. Environment variables (provider-specific with generic fallback)
+func (r *CredentialResolver) ResolveGitCredentials(
+	ctx context.Context,
+	namespace, secretRef string,
+) (token, username string, err error) {
+	// 1. App-specific secret reference
+	if secretRef != "" {
+		t, u, found := r.readSecret(ctx, namespace, secretRef)
+		if !found {
+			return "", "", fmt.Errorf("secret %q not found or missing 'token'/'password' key in namespace %q", secretRef, namespace)
+		}
+		return t, u, nil
+	}
+
+	// 2. Provider default secret
+	defaultSecret := r.provider.DefaultCredentialSecretName()
+	if t, u, found := r.readSecret(ctx, namespace, defaultSecret); found {
+		return t, u, nil
+	}
+
+	// 3. Environment variable fallback
+	token = readTokenEnv(r.provider)
+	username = readUserEnv(r.provider)
+	if username == "" {
+		username = r.provider.DefaultUsername()
+	}
+
+	if token == "" {
+		return "", "", fmt.Errorf(
+			"GitOps token is empty. Set %s or %s env var, create a Kubernetes Secret %q, or set GitOpsSecretRef",
+			r.provider.TokenEnvVar(), "GIT_TOKEN", defaultSecret,
+		)
+	}
+
+	return token, username, nil
+}
+
+// readSecret looks up a Kubernetes Secret and extracts the token and username.
+// Returns zero values and false if the secret is missing or lacks credentials.
+func (r *CredentialResolver) readSecret(ctx context.Context, namespace, name string) (token, username string, found bool) {
+	var secret corev1.Secret
+	if err := r.client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &secret); err != nil {
+		return "", "", false
+	}
+
+	if t, ok := secret.Data["token"]; ok {
+		token = string(t)
+	} else if p, ok := secret.Data["password"]; ok {
+		token = string(p)
+	} else {
+		return "", "", false
+	}
+
+	if u, ok := secret.Data["username"]; ok {
+		username = string(u)
+	}
+
+	return token, username, true
+}
+
+// readTokenEnv reads the auth token from the provider-specific env var,
+// falling back to the generic GIT_TOKEN.
+func readTokenEnv(p GitProvider) string {
+	if t := os.Getenv(p.TokenEnvVar()); t != "" {
+		return t
+	}
+	return os.Getenv("GIT_TOKEN")
+}
+
+// readUserEnv reads the username from the provider-specific env var,
+// falling back to the generic GIT_USER.
+func readUserEnv(p GitProvider) string {
+	if u := os.Getenv(p.UserEnvVar()); u != "" {
+		return u
+	}
+	return os.Getenv("GIT_USER")
+}

--- a/apps/operator/internal/provider/credentials_test.go
+++ b/apps/operator/internal/provider/credentials_test.go
@@ -1,0 +1,198 @@
+package provider
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCredentialResolver_AppSecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-git-secret", Namespace: "default"},
+		Data: map[string][]byte{
+			"token":    []byte("secret-token"),
+			"username": []byte("bot-user"),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+	resolver := NewCredentialResolver(fakeClient, NewGiteaProvider())
+
+	token, username, err := resolver.ResolveGitCredentials(t.Context(), "default", "my-git-secret")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "secret-token" {
+		t.Errorf("token = %q, want %q", token, "secret-token")
+	}
+	if username != "bot-user" {
+		t.Errorf("username = %q, want %q", username, "bot-user")
+	}
+}
+
+func TestCredentialResolver_AppSecretWithPassword(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-git-secret", Namespace: "default"},
+		Data: map[string][]byte{
+			"password": []byte("pass-token"),
+			"username": []byte("bot-user"),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+	resolver := NewCredentialResolver(fakeClient, NewGiteaProvider())
+
+	token, _, err := resolver.ResolveGitCredentials(t.Context(), "default", "my-git-secret")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "pass-token" {
+		t.Errorf("token = %q, want %q", token, "pass-token")
+	}
+}
+
+func TestCredentialResolver_MissingAppSecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	resolver := NewCredentialResolver(fakeClient, NewGiteaProvider())
+
+	_, _, err := resolver.ResolveGitCredentials(t.Context(), "default", "missing-secret")
+	if err == nil {
+		t.Fatal("expected error for missing secret")
+	}
+}
+
+func TestCredentialResolver_ProviderDefaultSecret(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+
+	defaultSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "helios-gitops-bot", Namespace: "default"},
+		Data: map[string][]byte{
+			"token":    []byte("default-token"),
+			"username": []byte("default-user"),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(defaultSecret).Build()
+	resolver := NewCredentialResolver(fakeClient, NewGiteaProvider())
+
+	token, username, err := resolver.ResolveGitCredentials(t.Context(), "default", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "default-token" {
+		t.Errorf("token = %q, want %q", token, "default-token")
+	}
+	if username != "default-user" {
+		t.Errorf("username = %q, want %q", username, "default-user")
+	}
+}
+
+func TestCredentialResolver_EnvVarFallback(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+
+	t.Setenv("GITEA_TOKEN", "env-token")
+	t.Setenv("GITEA_USER", "env-user")
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	resolver := NewCredentialResolver(fakeClient, NewGiteaProvider())
+
+	token, username, err := resolver.ResolveGitCredentials(t.Context(), "default", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "env-token" {
+		t.Errorf("token = %q, want %q", token, "env-token")
+	}
+	if username != "env-user" {
+		t.Errorf("username = %q, want %q", username, "env-user")
+	}
+}
+
+func TestCredentialResolver_GenericEnvVarFallback(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+
+	t.Setenv("GIT_TOKEN", "generic-token")
+	t.Setenv("GIT_USER", "generic-user")
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	resolver := NewCredentialResolver(fakeClient, NewGiteaProvider())
+
+	token, username, err := resolver.ResolveGitCredentials(t.Context(), "default", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "generic-token" {
+		t.Errorf("token = %q, want %q", token, "generic-token")
+	}
+	if username != "generic-user" {
+		t.Errorf("username = %q, want %q", username, "generic-user")
+	}
+}
+
+func TestCredentialResolver_NoCredentials(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	resolver := NewCredentialResolver(fakeClient, NewGiteaProvider())
+
+	_, _, err := resolver.ResolveGitCredentials(t.Context(), "default", "")
+	if err == nil {
+		t.Fatal("expected error when no credentials are configured")
+	}
+}
+
+func TestCredentialResolver_AppSecretTakesPriority(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(scheme)
+
+	appSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "app-secret", Namespace: "default"},
+		Data: map[string][]byte{
+			"token":    []byte("app-token"),
+			"username": []byte("app-user"),
+		},
+	}
+	defaultSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "helios-gitops-bot", Namespace: "default"},
+		Data: map[string][]byte{
+			"token": []byte("default-token"),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(appSecret, defaultSecret).Build()
+	resolver := NewCredentialResolver(fakeClient, NewGiteaProvider())
+
+	token, _, err := resolver.ResolveGitCredentials(t.Context(), "default", "app-secret")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "app-token" {
+		t.Errorf("token = %q, want %q (app secret should take priority)", token, "app-token")
+	}
+}
+
+func TestNewCredentialResolver(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().Build()
+	p := NewGiteaProvider()
+	resolver := NewCredentialResolver(fakeClient, p)
+	if resolver == nil {
+		t.Fatal("expected non-nil resolver")
+	}
+}

--- a/apps/operator/internal/provider/gitea.go
+++ b/apps/operator/internal/provider/gitea.go
@@ -58,3 +58,5 @@ func (p *GiteaProvider) DefaultUsername() string {
 func (p *GiteaProvider) TokenEnvVar() string { return "GITEA_TOKEN" }
 
 func (p *GiteaProvider) UserEnvVar() string { return "GITEA_USER" }
+
+func (p *GiteaProvider) DefaultCredentialSecretName() string { return "helios-gitops-bot" }

--- a/apps/operator/internal/provider/gitea_test.go
+++ b/apps/operator/internal/provider/gitea_test.go
@@ -65,6 +65,9 @@ func TestGiteaProvider_Defaults(t *testing.T) {
 	if got := p.UserEnvVar(); got != "GITEA_USER" {
 		t.Errorf("UserEnvVar() = %q, want %q", got, "GITEA_USER")
 	}
+	if got := p.DefaultCredentialSecretName(); got != "helios-gitops-bot" {
+		t.Errorf("DefaultCredentialSecretName() = %q, want %q", got, "helios-gitops-bot")
+	}
 }
 
 func TestGitHubProvider_RewriteURL(t *testing.T) {
@@ -98,6 +101,9 @@ func TestGitHubProvider_Defaults(t *testing.T) {
 	}
 	if got := p.UserEnvVar(); got != "GITHUB_USER" {
 		t.Errorf("UserEnvVar() = %q, want %q", got, "GITHUB_USER")
+	}
+	if got := p.DefaultCredentialSecretName(); got != "github-credentials" {
+		t.Errorf("DefaultCredentialSecretName() = %q, want %q", got, "github-credentials")
 	}
 }
 

--- a/apps/operator/internal/provider/github.go
+++ b/apps/operator/internal/provider/github.go
@@ -37,3 +37,5 @@ func (p *GitHubProvider) DefaultUsername() string {
 func (p *GitHubProvider) TokenEnvVar() string { return "GITHUB_TOKEN" }
 
 func (p *GitHubProvider) UserEnvVar() string { return "GITHUB_USER" }
+
+func (p *GitHubProvider) DefaultCredentialSecretName() string { return "github-credentials" }

--- a/apps/operator/internal/provider/provider.go
+++ b/apps/operator/internal/provider/provider.go
@@ -38,4 +38,8 @@ type GitProvider interface {
 
 	// UserEnvVar returns the environment variable name for the git username.
 	UserEnvVar() string
+
+	// DefaultCredentialSecretName returns the default Kubernetes Secret name
+	// used for git credentials when no explicit secret is configured.
+	DefaultCredentialSecretName() string
 }


### PR DESCRIPTION
## Overview

This PR completes the **Phase 2: Credential Resolution** plan. It transitions our Git authentication logic away from strict environment variable lookups to a more flexible, Kubernetes-native 3-tier secret resolution strategy.

## Credential Resolution Order (3 Tiers)
- **GitOpsSecretRef** (Highest Priority): Reads from the explicitly named Kubernetes Secret provided by the user configuration.
- **Provider Default:** Falls back to provider-defined defaults via `provider.DefaultCredentialSecretName()` (e.g., "helios-gitops-bot" for Gitea, "github-credentials" for GitHub).
- **Environment Fallback (Lowest Priority)**: Looks for provider-specific environment variables (GITEA_TOKEN/GITHUB_TOKEN), falling back further to generic environment keys (GIT_TOKEN / GIT_USER).

## Changes
### New Files
- `internal/provider/credentials.go`: Defines the `CredentialsResolver` interface and its unexported concrete implementation (`credentialResolver`).
- `internal/provider/credentials_test.go`: Comprehensive 9-test suite validating app secrets, custom keys, missing secrets, default provider secrets, env var cascading, and fallback priorities.

### Modified Files
- `internal/provider/provider.go`: Extended the GitProvider interface to include `DefaultCredentialSecretName()`.
- `internal/provider/gitea.go & github.go`: Implemented default naming schemes (helios-gitops-bot and github-credentials respectively).
- `internal/controller/gitopssync/reconciler.go`: Refactored to drop legacy local env helpers (`resolveCredentials`, `readTokenEnv`, etc.) in favor of the decoupled `provider.CredentialsResolver` interface.
- `internal/provider/gitea_test.go`: Added test coverage for the provider-specific default naming conventions.

## Verification & Testing Results
All local checks passed cleanly in the apps/operator context:
- `go build ./... & go vet ./...`: Clean
- `make build`: Successful (CRDs successfully regenerated, binaries built)

Test Suite Metrics:
- 15/15 provider unit tests passing (including the 9 new credential resolution edge cases).
- 2/2 controller unit tests passing.
- 1/1 envtest integration spec passing.

Ready for Phase 3: CUE Definitions (Generic Trigger Bundles).